### PR TITLE
renaming simple to kv-events and directory structure fixes

### DIFF
--- a/quickstart/examples/prefix-cache-aware/helmfile.yaml
+++ b/quickstart/examples/prefix-cache-aware/helmfile.yaml
@@ -3,7 +3,7 @@ repositories:
     url: https://llm-d-incubation.github.io/llm-d-modelservice/
 
 releases:
-  - name: infra-simple
+  - name: infra-kv-events
     namespace: llm-d
     chart: oci://ghcr.io/llm-d-incubation/llm-d-infra/llm-d-infra
     version: 1.0.5
@@ -11,17 +11,17 @@ releases:
     labels:
       managedBy: llm-d-infra-installer
 
-  - name: ms-simple
+  - name: ms-kv-events
     namespace: llm-d
     # chart: llm-d-modelservice/llm-d-modelservice
     # version: 0.0.16
     # waiting on: https://github.com/llm-d-incubation/llm-d-modelservice/pull/46
-    chart: ../../../../../llm-d-modelservice/charts/llm-d-modelservice/
+    # chart: ../../../../../llm-d-modelservice/charts/llm-d-modelservice/
     installed: true
     needs:
-      - llm-d/infra-simple
+      - llm-d/infra-kv-events
     values:
-      - ms-simple/values.yaml
+      - ms-kv-events/values.yaml
     labels:
       managedBy: helmfile
     hooks:
@@ -31,7 +31,7 @@ releases:
           - -c
           - |
             echo "Patching HTTPRoute to trigger reconciliation..."
-            kubectl patch httproute ms-simple-llm-d-modelservice \
+            kubectl patch httproute ms-kv-events-llm-d-modelservice \
               -n llm-d \
-              -p '{"metadata":{"labels":{"inferencepool":"ms-simple-llm-d-modelservice"}}}' \
+              -p '{"metadata":{"labels":{"inferencepool":"ms-kv-events-llm-d-modelservice"}}}' \
               --type=merge

--- a/quickstart/examples/prefix-cache-aware/ms-kv-events/values.yaml
+++ b/quickstart/examples/prefix-cache-aware/ms-kv-events/values.yaml
@@ -18,8 +18,8 @@ routing:
   parentRefs:
     - group: gateway.networking.k8s.io
       kind: Gateway
-      name: infra-simple-inference-gateway
-      
+      name: infra-kv-events-inference-gateway
+
   inferencePool:
     create: true
 
@@ -77,7 +77,7 @@ decode:
         --prefix-caching-hash-algo sha256_cbor_64bit \
         --enforce-eager \
         --kv-transfer-config '{"kv_connector":"NixlConnector", "kv_role":"kv_both"}' \
-        --kv-events-config "{\"enable_kv_cache_events\":true,\"publisher\":\"zmq\",\"endpoint\":\"tcp://ms-simple-llm-d-modelservice-epp:5557\",\"topic\":\"kv@${POD_IP}@Qwen/Qwen3-0.6B\"}" \
+        --kv-events-config "{\"enable_kv_cache_events\":true,\"publisher\":\"zmq\",\"endpoint\":\"tcp://ms-kv-events-llm-d-modelservice-epp:5557\",\"topic\":\"kv@${POD_IP}@Qwen/Qwen3-0.6B\"}" \
     env:
       - name: PYTHONHASHSEED
         value: "42"


### PR DESCRIPTION
Changes:

- Example should be named uniquely and so should all the helm chart releases to prevent confusion across examples (`simple` --> `kv-events`)
- Readme fixes and linting
- Tested example, everything works

Awesome job on this